### PR TITLE
remove sse from lobby sses on broken pipe

### DIFF
--- a/backend/src/main/java/io/castles/core/controller/LobbyController.java
+++ b/backend/src/main/java/io/castles/core/controller/LobbyController.java
@@ -56,15 +56,13 @@ public class LobbyController {
     }
 
     @GetMapping("/subscribe/{playerId}")
-    SseEmitter subscribe(@PathVariable("id") UUID id, @PathVariable("playerId") UUID playerId) {
-        var gameLobby = server.gameLobbyById(id);
-        var sseEmitter = this.emitterService.getLobbyEmitterForPlayer(id, playerId);
-        try {
-            lobbyService.updateLobbyState(gameLobby);
-        } catch (IOException e) {
-            // TODO: exception handling
-            throw new RuntimeException(e);
+    SseEmitter subscribe(@PathVariable("id") UUID id, @PathVariable("playerId") UUID playerId) throws IOException {
+        lobbyService.updateLobbyState(id);
+        var playerEmitter = this.emitterService.getLobbyEmitterForPlayer(id, playerId);
+        if (playerEmitter == null) {
+            playerEmitter = this.lobbyService.reconnectLobby(id, playerId);
+            this.lobbyService.updateLobbyStateToPlayer(id, playerId);
         }
-        return sseEmitter;
+        return playerEmitter;
     }
 }

--- a/backend/src/main/java/io/castles/core/service/LobbyService.java
+++ b/backend/src/main/java/io/castles/core/service/LobbyService.java
@@ -5,8 +5,12 @@ import io.castles.game.GameLobby;
 import io.castles.game.Player;
 import io.castles.game.Server;
 import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import javax.management.InstanceNotFoundException;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 
 @Service
@@ -21,19 +25,40 @@ public class LobbyService {
     }
 
     public void joinLobby(UUID id, Player player) throws IOException {
+
         var gameLobby = server.gameLobbyById(id);
         gameLobby.addPlayer(player); // TODO: exception handling
 
         var playerId = player.getId();
         emitterService.createPlayerEmitterForLobby(id, playerId);
 
-        updateLobbyState(gameLobby);
+        updateLobbyState(gameLobby.getId());
     }
 
-    public void updateLobbyState(GameLobby gameLobby) throws IOException {
+    public SseEmitter reconnectLobby(UUID id, UUID playerId) {
+        var gameLobby = server.gameLobbyById(id);
+        if (!gameLobby.isPlayerInLobby(playerId)) {
+            throw new NoSuchElementException(String.format("No player with id %s found in lobby %s", playerId, id));
+        }
+        this.emitterService.createPlayerEmitterForLobby(id, playerId);
+        return this.emitterService.getLobbyEmitterForPlayer(id, playerId);
+    }
+
+    public void updateLobbyState(UUID id) {
+        var gameLobby = server.gameLobbyById(id);
         var lobbySseEmitters = this.emitterService.getAllLobbyEmitters(gameLobby.getId());
         for (var playerSseEmitter : lobbySseEmitters) {
-            playerSseEmitter.send(LobbyStateDTO.from(gameLobby));
+            try {
+                playerSseEmitter.send(LobbyStateDTO.from(gameLobby));
+            } catch (IOException e) {
+                lobbySseEmitters.remove(playerSseEmitter);
+            }
         }
+    }
+
+    public void updateLobbyStateToPlayer(UUID id, UUID playerId) throws IOException {
+        var gameLobby = server.gameLobbyById(id);
+        var playerSseEmitter = this.emitterService.getLobbyEmitterForPlayer(gameLobby.getId(), playerId);
+        playerSseEmitter.send(LobbyStateDTO.from(gameLobby));
     }
 }

--- a/game/src/main/java/io/castles/game/GameLobby.java
+++ b/game/src/main/java/io/castles/game/GameLobby.java
@@ -56,12 +56,7 @@ public class GameLobby extends IdentifiableObject {
     }
 
     public boolean isPlayerInLobby(UUID playerId) {
-        try {
-            getPlayerById(playerId);
-            return true;
-        } catch (NoSuchElementException e) {
-            return false;
-        }
+        return this.players.contains(playerId);
     }
 
     public int getNumPlayers() {

--- a/game/src/main/java/io/castles/game/GameLobby.java
+++ b/game/src/main/java/io/castles/game/GameLobby.java
@@ -55,6 +55,14 @@ public class GameLobby extends IdentifiableObject {
                 .orElseThrow(() -> new NoSuchElementException(String.format("Player with if %s was not found in the list of players %s", playerId, players)));
     }
 
+    public boolean isPlayerInLobby(UUID playerId) {
+        try {
+            getPlayerById(playerId);
+            return true;
+        } catch (NoSuchElementException e) {
+            return false;
+        }
+    }
 
     public int getNumPlayers() {
         return players.size();


### PR DESCRIPTION
I had an error thrown when trying to reconnect a player after reloading the browser.
This happened because the pipe to the client breaks when refreshing the browser.

Solution is to remove the old connection from the lobbies sse emitters and open a new connection.
To guarantee, that the player requesting the reconnection is in the lobby, i check against the playerId.