### PR TITLE
Add default settings request

### DIFF
--- a/backend/src/main/java/io/castles/core/controller/ServerController.java
+++ b/backend/src/main/java/io/castles/core/controller/ServerController.java
@@ -1,5 +1,6 @@
 package io.castles.core.controller;
 
+import io.castles.core.model.LobbySettingsDTO;
 import io.castles.core.model.PlayerIdentificationDTO;
 import io.castles.game.Player;
 import io.castles.core.model.LobbyStateDTO;

--- a/backend/src/main/java/io/castles/core/controller/ServerController.java
+++ b/backend/src/main/java/io/castles/core/controller/ServerController.java
@@ -2,9 +2,13 @@ package io.castles.core.controller;
 
 import io.castles.core.model.LobbySettingsDTO;
 import io.castles.core.model.PlayerIdentificationDTO;
+import io.castles.core.service.LobbyService;
+import io.castles.game.GameLobbySettings;
 import io.castles.game.Player;
 import io.castles.core.model.LobbyStateDTO;
 import io.castles.game.Server;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,13 +19,11 @@ import java.util.stream.Collectors;
 @CrossOrigin(origins = "*", maxAge = 3600)
 @RestController
 @RequestMapping("/")
+@RequiredArgsConstructor
 public class ServerController {
 
     private final Server server;
-
-    public ServerController(Server server) {
-        this.server = server;
-    }
+    private final LobbyService lobbyService;
 
     @GetMapping("/status")
     @ResponseBody
@@ -29,13 +31,23 @@ public class ServerController {
         return HttpStatus.OK;
     }
 
+    @GetMapping("/settings")
+    @ResponseBody
+    LobbySettingsDTO getDefaultLobbySettings() {
+        var defaultSettings = GameLobbySettings.builder().build();
+        return LobbySettingsDTO.from(defaultSettings);
+    }
+
     @PostMapping("/lobby")
     @ResponseBody
-    PlayerIdentificationDTO createLobby(@RequestParam("lobbyName") String name, @RequestParam("playerName") String playerName) {
+    PlayerIdentificationDTO createLobby(@RequestParam("lobbyName") String name,
+                                        @RequestParam("playerName") String playerName,
+                                        @RequestBody() LobbySettingsDTO settings) {
         Player player = new Player(playerName);
-        var lobbyId = this.server.createGameLobby(name, player).getId();
+        var gameLobby = this.server.createGameLobby(name, player);
+        lobbyService.updateLobbySettings(gameLobby, settings);
 
-        return new PlayerIdentificationDTO(lobbyId, player.getId());
+        return new PlayerIdentificationDTO(gameLobby.getId(), player.getId());
     }
 
     @GetMapping("/lobbies")

--- a/backend/src/main/java/io/castles/core/model/LobbySettingsDTO.java
+++ b/backend/src/main/java/io/castles/core/model/LobbySettingsDTO.java
@@ -1,6 +1,7 @@
 package io.castles.core.model;
 
 import io.castles.core.GameMode;
+import io.castles.core.Visibility;
 import io.castles.core.tile.Tile;
 import io.castles.game.GameLobbySettings;
 import lombok.AccessLevel;
@@ -19,9 +20,11 @@ import java.util.stream.Stream;
 public class LobbySettingsDTO {
     private final int turnTimeSeconds;
     private final int maxPlayers;
-    private final String gameMode;
     private final List<Long> tileList;
+    private final String gameMode;
     private final List<String> gameModes;
+    private final String visibility;
+    private final List<String> visibilities;
 
     private boolean editable = false;
 
@@ -29,9 +32,11 @@ public class LobbySettingsDTO {
         return new LobbySettingsDTO(
                 lobbySettings.getTurnTimeSeconds(),
                 lobbySettings.getMaxPlayers(),
-                lobbySettings.getGameMode().toString(),
                 lobbySettings.getTileList().stream().map(Tile::getId).collect(Collectors.toList()),
-                Stream.of(GameMode.values()).map(Enum::name).collect(Collectors.toList())
+                lobbySettings.getGameMode().toString(),
+                Stream.of(GameMode.values()).map(Enum::name).collect(Collectors.toList()),
+                lobbySettings.getVisibility().toString(),
+                Stream.of(Visibility.values()).map(Enum::name).collect(Collectors.toList())
         );
     }
 }

--- a/backend/src/main/java/io/castles/core/service/LobbyService.java
+++ b/backend/src/main/java/io/castles/core/service/LobbyService.java
@@ -1,5 +1,8 @@
 package io.castles.core.service;
 
+import io.castles.core.GameMode;
+import io.castles.core.Visibility;
+import io.castles.core.model.LobbySettingsDTO;
 import io.castles.core.model.LobbyStateDTO;
 import io.castles.game.GameLobby;
 import io.castles.game.Player;
@@ -68,5 +71,13 @@ public class LobbyService {
             lobbyStateDTO.getLobbySettings().setEditable(true);
         }
         return lobbyStateDTO;
+    }
+
+    public void updateLobbySettings(GameLobby gameLobby, LobbySettingsDTO lobbySettingsDTO) {
+        var lobbySettings = gameLobby.getLobbySettings();
+        lobbySettings.setTurnTimeSeconds(lobbySettingsDTO.getTurnTimeSeconds());
+        lobbySettings.setMaxPlayers(lobbySettingsDTO.getMaxPlayers());
+        lobbySettings.setGameMode(GameMode.valueOf(lobbySettingsDTO.getGameMode()));
+        lobbySettings.setVisibility(Visibility.valueOf(lobbySettingsDTO.getVisibility()));
     }
 }

--- a/backend/src/test/java/io/castles/core/controller/LobbyControllerTest.java
+++ b/backend/src/test/java/io/castles/core/controller/LobbyControllerTest.java
@@ -42,7 +42,7 @@ class LobbyControllerTest {
     @Test
     void shouldGetPublicLobbyInfo() throws Exception {
         var owner = new Player("Owner");
-        var gameLobby = new GameLobby("Test", owner, GameLobby.Visibility.PUBLIC);
+        var gameLobby = new GameLobby("Test", owner);
 
         Mockito.when(server.gameLobbyById(any(UUID.class))).thenReturn(gameLobby);
         var urlTemplate = String.format("/lobby/%s/info", gameLobby.getId());
@@ -57,7 +57,7 @@ class LobbyControllerTest {
     @Test
     void shouldJoinAsPlayer() throws Exception {
         var owner = new Player("Owner");
-        var gameLobby = new GameLobby("Test", owner, GameLobby.Visibility.PUBLIC);
+        var gameLobby = new GameLobby("Test", owner);
         var sseEmitter = new SseEmitter();
         Mockito.when(server.gameLobbyById(any(UUID.class))).thenReturn(gameLobby);
         Mockito.when(emitterService.getLobbyEmitterForPlayer(any(UUID.class), any(UUID.class))).thenReturn(sseEmitter);
@@ -72,7 +72,7 @@ class LobbyControllerTest {
     @Test
     void shouldRemovePlayer() throws Exception {
         var owner = new Player("Owner");
-        var gameLobby = new GameLobby("Test", owner, GameLobby.Visibility.PUBLIC);
+        var gameLobby = new GameLobby("Test", owner);
         Mockito.when(server.gameLobbyById(any(UUID.class))).thenReturn(gameLobby);
 
         var urlTemplate = String.format("/lobby/%s/leave", gameLobby.getId());
@@ -86,7 +86,7 @@ class LobbyControllerTest {
     @Test
     void shouldStartAGame() throws Exception {
         var owner = new Player("Owner");
-        var gameLobby = new GameLobby("Test", owner, GameLobby.Visibility.PUBLIC);
+        var gameLobby = new GameLobby("Test", owner);
         for (int i = 0; i < GameLobby.MIN_PLAYERS; i++) {
             gameLobby.addPlayer(new Player("" + i));
         }
@@ -110,7 +110,7 @@ class LobbyControllerTest {
 
     void shouldBeAbleToSubscribeToSseEmitter() throws Exception {
         var owner = new Player("Owner");
-        var gameLobby = new GameLobby("Test", owner, GameLobby.Visibility.PUBLIC);
+        var gameLobby = new GameLobby("Test", owner);
         var player = new Player("P1");
         var emitter = new SseEmitter();
         Mockito.when(server.createGameLobby(any(String.class), any(Player.class))).thenReturn(gameLobby);

--- a/backend/src/test/java/io/castles/core/controller/ServerControllerTest.java
+++ b/backend/src/test/java/io/castles/core/controller/ServerControllerTest.java
@@ -32,7 +32,7 @@ class ServerControllerTest {
     void shouldCreateNewLobby() throws Exception {
         var lobbyName = "Test";
         var player = new Player("P1");
-        var gameLobby = new GameLobby(lobbyName, player, GameLobby.Visibility.PUBLIC);
+        var gameLobby = new GameLobby(lobbyName, player);
         Mockito.when(server.createGameLobby(any(String.class), any(Player.class))).thenReturn(gameLobby);
         mvc.perform(MockMvcRequestBuilders.post("/lobby").param("lobbyName", lobbyName).param("playerName", "P2"))
                 .andExpect(status().isOk())

--- a/game/src/main/java/io/castles/core/Visibility.java
+++ b/game/src/main/java/io/castles/core/Visibility.java
@@ -1,0 +1,6 @@
+package io.castles.core;
+
+public enum Visibility {
+    PUBLIC,
+    PRIVATE
+}

--- a/game/src/main/java/io/castles/game/GameLobby.java
+++ b/game/src/main/java/io/castles/game/GameLobby.java
@@ -1,6 +1,7 @@
 package io.castles.game;
 
 import io.castles.core.GameMode;
+import io.castles.core.Visibility;
 import io.castles.core.tile.Tile;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -9,20 +10,13 @@ public class GameLobby extends IdentifiableObject {
 
     public static final int MIN_PLAYERS = 2;
 
-    private final Visibility visibility;
     private final Set<Player> players;
     private final GameLobbySettings lobbySettings;
     private final String name;
     private Player owner;
 
-    public enum Visibility {
-        PUBLIC,
-        PRIVATE
-    }
-
-    public GameLobby(String name, Player owner, Visibility visibility) {
+    public GameLobby(String name, Player owner) {
         this.name = name;
-        this.visibility = visibility;
         this.players = new HashSet<>();
         this.owner = owner;
         this.players.add(owner);
@@ -30,7 +24,7 @@ public class GameLobby extends IdentifiableObject {
     }
 
     boolean isPublic() {
-        return visibility == Visibility.PUBLIC;
+        return this.lobbySettings.getVisibility() == Visibility.PUBLIC;
     }
 
     Game startGame() {

--- a/game/src/main/java/io/castles/game/GameLobbySettings.java
+++ b/game/src/main/java/io/castles/game/GameLobbySettings.java
@@ -1,6 +1,7 @@
 package io.castles.game;
 
 import io.castles.core.GameMode;
+import io.castles.core.Visibility;
 import io.castles.core.tile.Tile;
 import lombok.Builder;
 import lombok.Data;
@@ -19,4 +20,6 @@ public class GameLobbySettings {
     private GameMode gameMode = GameMode.ORIGINAL;
     @Builder.Default
     private List<Tile> tileList = List.of();
+    @Builder.Default
+    private Visibility visibility = Visibility.PUBLIC;
 }

--- a/game/src/main/java/io/castles/game/Server.java
+++ b/game/src/main/java/io/castles/game/Server.java
@@ -25,13 +25,7 @@ public class Server {
     }
 
     public GameLobby createGameLobby(String name, Player owner) {
-        var gameLobby = new GameLobby(name, owner, GameLobby.Visibility.PUBLIC);
-        activeLobbies.put(gameLobby.getId(), gameLobby);
-        return gameLobby;
-    }
-
-    public GameLobby createGameLobby(String name, Player owner, GameLobby.Visibility visibility) {
-        var gameLobby = new GameLobby(name, owner, visibility);
+        var gameLobby = new GameLobby(name, owner);
         activeLobbies.put(gameLobby.getId(), gameLobby);
         return gameLobby;
     }

--- a/game/src/test/java/io/castles/game/GameLobbyTest.java
+++ b/game/src/test/java/io/castles/game/GameLobbyTest.java
@@ -15,7 +15,7 @@ class GameLobbyTest {
 
     @BeforeEach
     void setup() {
-        this.gameLobby = new GameLobby("Test", new Player("owner"), GameLobby.Visibility.PUBLIC);
+        this.gameLobby = new GameLobby("Test", new Player("owner"));
     }
 
     @Test

--- a/game/src/test/java/io/castles/game/ServerTest.java
+++ b/game/src/test/java/io/castles/game/ServerTest.java
@@ -1,6 +1,7 @@
 package io.castles.game;
 
 import io.castles.core.GameMode;
+import io.castles.core.Visibility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -49,9 +50,10 @@ class ServerTest {
 
     @Test
     void shouldListPublicLobbies() {
-        GameLobby lobby1 = server.createGameLobby("lobby1", new Player("owner"), GameLobby.Visibility.PUBLIC);
-        GameLobby lobby2 = server.createGameLobby("lobby2", new Player("owner"), GameLobby.Visibility.PRIVATE);
-        GameLobby lobby3 = server.createGameLobby("lobby3", new Player("owner"), GameLobby.Visibility.PUBLIC);
+        GameLobby lobby1 = server.createGameLobby("lobby1", new Player("owner"));
+        GameLobby lobby2 = server.createGameLobby("lobby2", new Player("owner"));
+        lobby2.getLobbySettings().setVisibility(Visibility.PRIVATE);
+        GameLobby lobby3 = server.createGameLobby("lobby3", new Player("owner"));
 
         assertThat(server.publicGameLobbies()).containsExactlyInAnyOrderElementsOf(List.of(lobby1, lobby3));
     }


### PR DESCRIPTION
- changes visibility to be set in `GameLobbySettings`, not in `GameLobby`
- adds request to get default lobby settings
- adds settings body to create lobby request
- allows `GameLobbySettings` to be changed based on given `LobbySettingsDTO` in `LobbyService`.